### PR TITLE
Fixed knot folding regex, added Control-L shortcut to toggle the current block

### DIFF
--- a/app/renderer/ace-ink-mode/ace-ink.js
+++ b/app/renderer/ace-ink-mode/ace-ink.js
@@ -526,7 +526,7 @@ oop.inherits(inkFoldingRules, BaseFoldMode);
 
     // Use a regular expression to say which line starts a fold.   
 
-    this.foldingStartMarker =  /^(\s*)(=)(?<knot>==)?(\s*)((?:function)?)(\s*)(\w+)(\s*)(\([\w,\s->]*\))?(\s*)((?:={1,})?)/; 
+    this.foldingStartMarker =  /^(\s*)(=)(?<knot>={1,})?(\s*)((?:function)?)(\s*)(\w+)(\s*)(\([\w,\s->]*\))?(\s*)((?:={1,})?)/; 
 
     // Get the range of text that will be included in the fold. 
 
@@ -550,7 +550,7 @@ oop.inherits(inkFoldingRules, BaseFoldMode);
 
         // Collect all text into the fold until you get to a knot
 
-        var endLineRegex = /^(\s*)(===)(\s*)((?:function)?)(\s*)(\w+)(\s*)(\([\w,\s->]*\))?(\s*)((?:={1,})?)/
+        var endLineRegex = /^(\s*)(={2,})(\s*)((?:function)?)(\s*)(\w+)(\s*)(\([\w,\s->]*\))?(\s*)((?:={1,})?)/
         return this.getRangeFromStartToRegex(session, foldStyle, row, line, endLineRegex)
     }
 
@@ -558,7 +558,7 @@ oop.inherits(inkFoldingRules, BaseFoldMode);
 
         // Collect all text into the fold until you get to a knot or a stitch
 
-        var endLineRegex = /^(\s*)(=)(==)?(\s*)((?:function)?)(\s*)(\w+)(\s*)(\([\w,\s->]*\))?(\s*)((?:={1,})?)/
+        var endLineRegex = /^(\s*)(={1,})?(\s*)((?:function)?)(\s*)(\w+)(\s*)(\([\w,\s->]*\))?(\s*)((?:={1,})?)/
         return this.getRangeFromStartToRegex(session, foldStyle, row, line, endLineRegex)
     }
 

--- a/app/renderer/acesrc/ace.js
+++ b/app/renderer/acesrc/ace.js
@@ -8183,7 +8183,6 @@ function Folding() {
     this.toggleFoldBlock = function(editor)
     {
         var foldWidgets = this.foldWidgets;
-        console.log(foldWidgets);
         if (!foldWidgets)
             return; // mode doesn't support folding
 
@@ -11056,7 +11055,7 @@ exports.commands = [{
     readOnly: true
 }, {
     name: "gotoline",
-    bindKey: bindKey("Ctrl-L", "Command-L"),
+    bindKey: bindKey("Ctrl-G", "Command-G"),
     exec: function(editor) {
         var line = parseInt(prompt("Enter line number:"), 10);
         if (!isNaN(line)) {
@@ -11111,7 +11110,7 @@ exports.commands = [{
     name: "toggleFoldBlock",
     bindKey: bindKey("Control-L", "Command-L"),
     exec: function(editor) {     
-    	editor.session.foldBlock(editor);
+    	editor.session.toggleFoldBlock(editor);
     },
     scrollIntoView: "center",
     readOnly: true

--- a/app/renderer/acesrc/ace.js
+++ b/app/renderer/acesrc/ace.js
@@ -8179,6 +8179,44 @@ function Folding() {
             return range;
         }
     };
+    
+    this.toggleFoldBlock = function(editor)
+    {
+        var foldWidgets = this.foldWidgets;
+        console.log(foldWidgets);
+        if (!foldWidgets)
+            return; // mode doesn't support folding
+
+    	var startRow = editor.getSelectionRange().start.row;     
+        if (!startRow && !foldWidgets[startRow])
+        	return;
+        	
+        for (var row = startRow; row >= 0; row--)
+        {
+            if (foldWidgets[row] == null)
+                foldWidgets[row] = this.getFoldWidget(row);
+            if (foldWidgets[row] != "start")
+                continue;
+                        
+            var oldFold = this.getFoldAt(row, this.getLine(row).length, 1);
+            if (oldFold)
+            { 
+                this.expandFold(oldFold);
+            }
+            else
+            {
+                var range = this.getFoldWidgetRange(row);
+                row = range.end.row;
+                try {
+                    var fold = this.addFold("...", range);
+                    if (fold)
+                        fold.collapseChildren = depth;
+                } catch(e) {}    
+            }
+
+            break;
+        }
+    }
 
     this.foldAll = function(startRow, endRow, depth) {
         if (depth == undefined)
@@ -11070,7 +11108,15 @@ exports.commands = [{
     scrollIntoView: "center",
     readOnly: true
 }, {
-    name: "unfoldall",
+    name: "toggleFoldBlock",
+    bindKey: bindKey("Control-L", "Command-L"),
+    exec: function(editor) {     
+    	editor.session.foldBlock(editor);
+    },
+    scrollIntoView: "center",
+    readOnly: true
+}, {    
+	name: "unfoldall",
     bindKey: bindKey("Alt-Shift-0", "Command-Option-Shift-0"),
     exec: function(editor) { editor.session.unfold(); },
     scrollIntoView: "center",


### PR DESCRIPTION
Knot regex now matches knots with two or more equals signs.

Added a shortcut (Control-L or Command-L) to toggle the current knot or stitch you're working in.

Also removed the previous binding to Control-L (go to line) because it was triggering an error in the console every time it was pressed? Bizarre, not sure what's going on with that. 